### PR TITLE
Custom bindings for Galaxy Cam Translate X/Y-Axis

### DIFF
--- a/config/Custom.binds
+++ b/config/Custom.binds
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<Root>
+<Root PresetName="Custom">
 	<KeyboardLayout>en-GB</KeyboardLayout>
 	<MouseXMode Value="" />
 	<MouseXDecay Value="1" />
@@ -556,8 +556,8 @@
 		<Secondary Device="{NoDevice}" Key="" />
 	</CamYawRight>
 	<CamTranslateYAxis>
-		<Binding Device="068EC010" Key="Joy_RZAxis" />
-		<Inverted Value="0" />
+		<Binding Device="068EC010" Key="Joy_RYAxis" />
+		<Inverted Value="1" />
 		<Deadzone Value="0.00000000" />
 	</CamTranslateYAxis>
 	<CamTranslateForward>
@@ -569,7 +569,7 @@
 		<Secondary Device="{NoDevice}" Key="" />
 	</CamTranslateBackward>
 	<CamTranslateXAxis>
-		<Binding Device="068EC010" Key="Joy_RYAxis" />
+		<Binding Device="068EC010" Key="Joy_RZAxis" />
 		<Inverted Value="0" />
 		<Deadzone Value="0.00000000" />
 	</CamTranslateXAxis>


### PR DESCRIPTION
The following code change adjusts the Elite: Dangerous Options for Controls so that the throttle joystick can be used to navigate new routes. See the Issue #8 for a complete description of what I'm trying to solve here.